### PR TITLE
Bug 1453205 - Un-flip the media.cubeb.sandbox pref.

### DIFF
--- a/desktop/ubuntu/distribution/distribution.ini
+++ b/desktop/ubuntu/distribution/distribution.ini
@@ -16,5 +16,4 @@ browser.search.geoSpecificDefaults=false
 browser.shell.checkDefaultBrowser=false
 intl.locale.matchOS=true
 intl.locale.requested=""
-media.cubeb.sandbox=false
 mozilla.partner.id="ubuntu"


### PR DESCRIPTION
media.cubeb.sandbox controls whether audio hardware access is proxied
through the parent process; setting it to false, as a side effect, turns
off various aspects of sandboxing that conflict with the PulseAudio
client libraries.  It was flipped in bug 1449594 because it happened to
work around an interaction between sandboxing and the Snap container
environment, but the underlying issue was fixed in bug 1450740 and should
be present in 60 beta builds since 60.0b11.

Testing done: installed the latest beta Snap, 60.0b13, manually
un-flipped the pref in about:config and restarted, and checked basic
functionality as well as WebAudio and WebGL.